### PR TITLE
Support building on freebsd

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,6 +14,7 @@
 
 {pre_hooks, [{'get-deps', "c_src/build_deps.sh get-deps"},
              {compile, "c_src/build_deps.sh"},
-             {compile, "make -C c_src"}]}.
+             {"(linux|darwin|solaris)", compile, "make -C c_src"},
+             {"freebsd", compile, "gmake -C c_src"}]}.
 
 {post_hooks, [{clean, "c_src/build_deps.sh clean"}]}.


### PR DESCRIPTION
Change the rebar.config file according to https://murf.se/2018/11/02/compiling-vernemq-on-freebsd.html to make it compile on FreeBSD.

Tested this change (together with the `vmq_passwd` one which will be included in a PR against the vernemq repo) and with this it builds out of the box on FreeBSD-11.2-RELEASE with `gmake rel`.

It should be noted that with this change we can stilll build for linux - tested that

If this is approved it will be followed by a PR for plumtree and finally one for VerneMQ