### PR TITLE
Support FreeBSD 12.1

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -6,6 +6,7 @@ BASEDIR := $(abspath $(CURDIR)/..)
 PROJECT ?= $(notdir $(BASEDIR))
 PROJECT := $(strip $(PROJECT))
 
+ERLANG_VERSION_GT_22 := $(shell erl -noshell -s init stop -eval "erlang:display(erlang:system_info(otp_release) > "22").")
 ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")
 ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)]).")
 ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)]).")
@@ -16,15 +17,23 @@ C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so
 # System type and C compiler/flags.
 
 UNAME_SYS := $(shell uname -s)
+SNAPPY_STATIC_OR_DYN_LIB := system/lib/libsnappy.a
+
 ifeq ($(UNAME_SYS), Darwin)
     CC ?= cc
-    CFLAGS ?= -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes 
+    CFLAGS ?= -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
     CXXFLAGS ?= -O3 -arch x86_64 -finline-functions -Wall -stdlib=libstdc++
     LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress  -stdlib=libstdc++
 else ifeq ($(UNAME_SYS), FreeBSD)
     CC ?= cc
     CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
     CXXFLAGS ?= -O3 -finline-functions -Wall
+    FREEBSD_MAJOR_VERSION := $(shell uname -U | cut -c1-2)
+
+    ifeq ($(FREEBSD_MAJOR_VERSION), 12)
+        SNAPPY_STATIC_OR_DYN_LIB = /usr/local/lib/libsnappy.so
+    endif
+
 else ifeq ($(UNAME_SYS), Linux)
     CC ?= gcc
     CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
@@ -34,8 +43,13 @@ endif
 CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I leveldb/include
 CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR) -I leveldb/include
 
-LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lerl_interface -lei
-LDFLAGS += -shared leveldb/libleveldb.a system/lib/libsnappy.a -lstdc++
+ifeq ($(ERLANG_VERSION_GT_22), true)
+    LDLIBS += -L$(ERL_INTERFACE_LIB_DIR) -lei
+else
+    LDLIBS += -L$(ERL_INTERFACE_LIB_DIR) -lerl_interface -lei
+endif
+
+LDFLAGS += -shared leveldb/libleveldb.a $(SNAPPY_STATIC_OR_DYN_LIB) -lstdc++
 
 # Verbosity.
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 %%-*- mode: erlang -*-
-{plugins, [pc]}. 
+{plugins, [pc]}.
 
 {artifacts, ["priv/eleveldb.so"]}.
 
@@ -24,12 +24,13 @@
 	    {"CFLAGS", "$CFLAGS -Wall -O3 -fPIC"},
 	    {"CXXFLAGS", "$CXXFLAGS -Wall -O3 -fPIC"},
 	    {"DRV_CFLAGS", "$DRV_CFLAGS -O3 -Wall -I c_src/leveldb/include -I c_src/leveldb -I c_src/system/include"},
-	    {"DRV_LDFLAGS", "$DRV_LDFLAGS c_src/leveldb/libleveldb.a -lsnappy -lstdc++"}
+	    {"(freebsd)", "DRV_LDFLAGS", "$DRV_LDFLAGS c_src/leveldb/libleveldb.a -lstdc++"},
+	    {"^(?s)((?!freebsd).)*$", "DRV_LDFLAGS", "$DRV_LDFLAGS c_src/leveldb/libleveldb.a -lsnappy -lstdc++"}
 	   ]}.
 
 {pre_hooks, [
              {"(linux|darwin|solaris|freebsd)", compile, "c_src/build_deps.sh get-deps"},
-             {"(linux|darwin|solaris|freebsd)", compile, "c_src/build_deps.sh"} 
+             {"(linux|darwin|solaris|freebsd)", compile, "c_src/build_deps.sh"}
             ]}.
 
 {provider_hooks, [


### PR DESCRIPTION
These changes allow eleveldb to build on FreeBSD 12 by fixing both issues below:

1. eleveldb's Makefile is trying to include `-lerl_interface` in the LDFlags environment var. This is all good and fine as long as the system is being built against Erlang < 23. Erlang 23 does away with this library and instead justs asks developers to use `-lei` which is already done by eleveldb.

2. rebar3 is applying the LDFLAGS `-lsnappy` parameter to include Google's Snappy as a static library. FreeBSD 12 no longer bundles libsnappy as a static library and instead is now a shared dynamic library in `/usr/local/lib` when installed via `pkg install snappy`. Given that `/usr/local/lib` is part of the normal Linker (ld) search paths there is no need to specify a path to it in rebar.config.

Even though vernemq builds perfectly fine on my FreeBSD 12.1p8 machine I admit its possible the fix for issue 2 above (which is done by making a change to rebar.config) may break on FreeBSD machines prior to 12 since the fix is applied to all freebsd versions _More testing on that would be gladly appreciated_. I don't know how to program in erlang and am not too familiar with rebar3 and its configs so I'm not sure how to apply the fix for issue 2 only to FreeBSD versions of 12 and higher.

Also of note is that I'm not really sure if the fix for issue 1 is even needed. Yes if you enter eleveldb/c_src and do `gmake` it won't compile without my changes but even without this fix it seems the fix for issue2 allows rebar to build eleveldb succesfully. It does make me question the reason for the Makefile in c_src and if `rebar3 compile` skips using it..